### PR TITLE
fix: disambiguate readings sharing one LHM SensorId (#60)

### DIFF
--- a/com.moeilijk.lhm.sdPlugin/manifest.json
+++ b/com.moeilijk.lhm.sdPlugin/manifest.json
@@ -77,7 +77,7 @@
   "Icon": "pluginIcon",
   "CategoryIcon": "categoryIcon",
   "URL": "https://github.com/moeilijk/lhm-streamdeck",
-  "Version": "1.9.0.0",
+  "Version": "1.9.1.0",
   "ApplicationsToMonitor": {
     "windows": [
       "LibreHardwareMonitor.EXE",

--- a/internal/lhm/plugin/service.go
+++ b/internal/lhm/plugin/service.go
@@ -207,6 +207,7 @@ func buildSnapshot(root *node) (map[string]*sensor, []string, map[string][]*read
 	sensors := make(map[string]*sensor)
 	sensorOrder := make([]string, 0)
 	readings := make(map[string][]*reading)
+	usedIDs := make(map[string]map[int32]bool)
 
 	var walk func(n *node, ancestors []*node)
 	walk = func(n *node, ancestors []*node) {
@@ -221,6 +222,23 @@ func buildSnapshot(root *node) (map[string]*sensor, []string, map[string][]*read
 				sensorOrder = append(sensorOrder, sid)
 			}
 			if r := newReading(sid, n); r != nil {
+				if usedIDs[sid] == nil {
+					usedIDs[sid] = make(map[int32]bool)
+				}
+				// Workaround for LibreHardwareMonitor bug #1441: NVIDIA exposes
+				// two distinct Load readings ("GPU Memory" and "GPU Bus") with an
+				// identical SensorId (/gpu-nvidia/0/load/3, the hardcoded index 3
+				// in NvidiaGpu.cs collides with the bus interface utilization), so
+				// makeReadingID produces the same id and the second reading becomes
+				// unselectable. Keep the first occurrence canonical (backward
+				// compatible with already-saved button settings) and derive a
+				// stable, distinct id for later duplicates from the label.
+				// Remove once LHM ships the upstream fix (>= v0.9.7) and duplicate
+				// SensorIds no longer occur.
+				if usedIDs[sid][r.id] {
+					r.id = disambiguateReadingID(sid, n.SensorID, r.label, usedIDs[sid])
+				}
+				usedIDs[sid][r.id] = true
 				readings[sid] = append(readings[sid], r)
 			}
 			return
@@ -330,6 +348,28 @@ func makeReadingID(sensorID, readingID string) int32 {
 	_, _ = h.Write([]byte(sensorID))
 	_, _ = h.Write([]byte(readingID))
 	return int32(h.Sum32() & 0x7fffffff)
+}
+
+// disambiguateReadingID derives a stable reading id that does not collide with
+// ids already used within the same sensor. It mixes the reading label into the
+// hash so distinct readings sharing one SensorId (see LHM bug #1441) get
+// distinct ids, falling back to an incrementing suffix if a collision remains.
+func disambiguateReadingID(sensorID, readingID, label string, used map[int32]bool) int32 {
+	for attempt := 0; ; attempt++ {
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(sensorID))
+		_, _ = h.Write([]byte(readingID))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(label))
+		if attempt > 0 {
+			_, _ = h.Write([]byte{0})
+			_, _ = h.Write([]byte(strconv.Itoa(attempt)))
+		}
+		id := int32(h.Sum32() & 0x7fffffff)
+		if !used[id] {
+			return id
+		}
+	}
 }
 
 func mapReadingType(t string) hwsensorsservice.ReadingType {

--- a/internal/lhm/plugin/service_test.go
+++ b/internal/lhm/plugin/service_test.go
@@ -53,3 +53,59 @@ func TestBuildSnapshotFromExample(t *testing.T) {
 		t.Fatalf("expected CPU Total reading")
 	}
 }
+
+// TestBuildSnapshotDisambiguatesDuplicateSensorID covers LibreHardwareMonitor
+// bug #1441: NVIDIA exposes "GPU Memory" and "GPU Bus" with an identical
+// SensorId (/gpu-nvidia/0/load/3). Both readings must still get distinct ids so
+// each is independently selectable, and the first occurrence must keep its
+// canonical id so already-saved button settings keep resolving.
+func TestBuildSnapshotDisambiguatesDuplicateSensorID(t *testing.T) {
+	root := node{
+		Text: "Computer",
+		Children: []node{
+			{
+				Text: "NVIDIA GeForce RTX 3090 Ti",
+				Children: []node{
+					{Text: "Load", Children: []node{
+						{Text: "GPU Core", Value: "10,0 %", SensorID: "/gpu-nvidia/0/load/0", Type: "Load"},
+						{Text: "GPU Memory", Value: "20,0 %", SensorID: "/gpu-nvidia/0/load/3", Type: "Load"},
+						{Text: "GPU Bus", Value: "30,0 %", SensorID: "/gpu-nvidia/0/load/3", Type: "Load"},
+					}},
+				},
+			},
+		},
+	}
+
+	_, _, readings := buildSnapshot(&root)
+	rs := readings["/gpu-nvidia/0"]
+	if len(rs) != 3 {
+		t.Fatalf("expected 3 readings, got %d", len(rs))
+	}
+
+	byID := make(map[int32]string)
+	byLabel := make(map[string]int32)
+	for _, r := range rs {
+		if prev, ok := byID[r.id]; ok {
+			t.Fatalf("duplicate reading id %d shared by %q and %q", r.id, prev, r.label)
+		}
+		byID[r.id] = r.label
+		byLabel[r.label] = r.id
+	}
+
+	// First occurrence keeps the canonical id (backward compatible).
+	canonical := makeReadingID("/gpu-nvidia/0", "/gpu-nvidia/0/load/3")
+	if byLabel["GPU Memory"] != canonical {
+		t.Fatalf("GPU Memory should keep canonical id %d, got %d", canonical, byLabel["GPU Memory"])
+	}
+	if byLabel["GPU Bus"] == canonical {
+		t.Fatalf("GPU Bus must be disambiguated from the canonical id %d", canonical)
+	}
+
+	// Disambiguation must be stable across snapshots.
+	_, _, readings2 := buildSnapshot(&root)
+	for _, r := range readings2["/gpu-nvidia/0"] {
+		if byLabel[r.label] != r.id {
+			t.Fatalf("unstable id for %q: %d vs %d", r.label, byLabel[r.label], r.id)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #60.

## Problem
LibreHardwareMonitor (bug [#1441](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/issues/1441), still present in 0.9.6) exposes two distinct NVIDIA Load readings — **GPU Memory** and **GPU Bus** — with an identical `SensorId` (`/gpu-nvidia/0/load/3`). `makeReadingID` then produced the same id, so the second reading collided with the first: resolved to the wrong reading via first-match lookup, reverted its label on revisit, showed the wrong value, and was dropped during bulk-add.

## Fix
`buildSnapshot` now tracks reading ids per sensor. The first occurrence keeps its canonical id (backward compatible with already-saved button settings); later duplicates get a stable, label-derived id. Both readings become independently selectable with correct values. Removable once LHM ships the upstream fix (>= v0.9.7, PR [#2310](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor/pull/2310)).

## Validation
- New Go unit test `TestBuildSnapshotDisambiguatesDuplicateSensorID` (duplicate `SensorId` -> distinct ids, first canonical, stable across snapshots).
- `make verify` green; local deploy + hardware test confirmed on RTX 3090 Ti.
- Manifest bumped to 1.9.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)