### PR TITLE
chore: hide dial PI build row

### DIFF
--- a/com.moeilijk.lhm.sdPlugin/dial_pi.html
+++ b/com.moeilijk.lhm.sdPlugin/dial_pi.html
@@ -79,10 +79,9 @@
   <div id="ui" class="sdpi-wrapper localbody hiddenx">
     <div class="sdpi-heading">Source</div>
 
-    <div class="sdpi-item" id="pluginBuildRef">
-      <div class="sdpi-item-label">Build</div>
-      <div class="sdpi-item-value" title="Plugin commit 3c5e9b5 plus local V5 prep fixes">3c5e9b5 + V5-prep.39</div>
-    </div>
+    <!-- Build: 3c5e9b5 + V5-prep.40 (plugin commit 3c5e9b5 plus local V5 prep fixes).
+         Kept as a comment for traceability without taking up PI space; bump it
+         together with the ?v= cache-busters at the bottom of this file. -->
 
     <div class="sdpi-item">
       <div class="sdpi-item-label">Profile</div>
@@ -593,8 +592,8 @@
     </template>
   </div>
 
-  <script src="pi_utils.js?v=V5-prep.39"></script>
-  <script src="dial_pi.js?v=V5-prep.39"></script>
+  <script src="pi_utils.js?v=V5-prep.40"></script>
+  <script src="dial_pi.js?v=V5-prep.40"></script>
 </body>
 
 </html>

--- a/scripts/test-dial-pi.js
+++ b/scripts/test-dial-pi.js
@@ -309,11 +309,12 @@ function testRemoveSelectedPage() {
   assert(sb.currentSettings.activeIndex === 0, "active index clamped");
 }
 
-function testBuildRefVisibleInPi() {
+function testBuildRefTraceableNotVisible() {
   const html = fs.readFileSync("com.moeilijk.lhm.sdPlugin/dial_pi.html", "utf8");
-  assert(html.includes('id="pluginBuildRef"'), "plugin build ref row present");
-  assert(html.includes("3c5e9b5 + V5-prep.39"), "plugin V5 build ref visible in PI");
-  assert(html.includes('dial_pi.js?v=V5-prep.39'), "dial PI script is cache-busted with build ref");
+  // The build ref is traceable as a comment but must NOT occupy a visible PI row.
+  assert(!html.includes('id="pluginBuildRef"'), "build ref must not be a visible PI row");
+  assert(/<!--[^>]*Build: 3c5e9b5 \+ V5-prep\.40/.test(html), "build ref present as a comment");
+  assert(html.includes('dial_pi.js?v=V5-prep.40'), "dial PI script is cache-busted with build ref");
   assert(html.includes("Dial press"), "dial-press row present");
   assert(html.includes("Toggle overview"), "dial-press behavior visible");
   assert(html.includes('id="globalThresholdsSection" hidden'), "global thresholds section starts hidden");
@@ -708,7 +709,7 @@ const tests = [
   ["add page button sends settings", testAddPageButtonSendsSettings],
   ["moveSelectedPage", testMoveSelectedPage],
   ["removeSelectedPage", testRemoveSelectedPage],
-  ["build ref visible in PI", testBuildRefVisibleInPi],
+  ["build ref traceable as comment, not a visible row", testBuildRefTraceableNotVisible],
   ["bulk preview list uses dark PI select style", testBulkPreviewListUsesDarkPiSelectStyle],
   ["snooze duration normalization", testSnoozeDurationNormalization],
   ["threshold helpers", testThresholdHelpers],


### PR DESCRIPTION
Moves the dial Property Inspector's visible "Build" row into an HTML comment so it no longer takes up PI space, while staying traceable. Build ref bumped to V5-prep.40 alongside the `?v=` cache-busters; the PI test now asserts the build ref is present as a comment and not as a visible row.

## Validation

- `node scripts/test-dial-pi.js`, `scripts/verify-settings-pi.sh` green.
- Deployed and verified in the DeckBridge emulator (the row is gone; dial PI is Stream Deck+ only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)