### PR TITLE
fix: harden dial PI against prototype pollution (CodeQL)

### DIFF
--- a/com.moeilijk.lhm.sdPlugin/dial_pi.html
+++ b/com.moeilijk.lhm.sdPlugin/dial_pi.html
@@ -79,7 +79,7 @@
   <div id="ui" class="sdpi-wrapper localbody hiddenx">
     <div class="sdpi-heading">Source</div>
 
-    <!-- Build: 3c5e9b5 + V5-prep.40 (plugin commit 3c5e9b5 plus local V5 prep fixes).
+    <!-- Build: 3c5e9b5 + V5-prep.41 (plugin commit 3c5e9b5 plus local V5 prep fixes).
          Kept as a comment for traceability without taking up PI space; bump it
          together with the ?v= cache-busters at the bottom of this file. -->
 
@@ -592,8 +592,8 @@
     </template>
   </div>
 
-  <script src="pi_utils.js?v=V5-prep.40"></script>
-  <script src="dial_pi.js?v=V5-prep.40"></script>
+  <script src="pi_utils.js?v=V5-prep.41"></script>
+  <script src="dial_pi.js?v=V5-prep.41"></script>
 </body>
 
 </html>

--- a/com.moeilijk.lhm.sdPlugin/dial_pi.js
+++ b/com.moeilijk.lhm.sdPlugin/dial_pi.js
@@ -4,10 +4,17 @@ var websocket = null,
   currentSettings = { activeIndex: 0, pages: [] },
   currentCatalog = { sensors: [], readings: [], sourceProfiles: [] },
   pageSelectionDraft = { sensorUid: "", readingId: "" },
-  thresholdAdvancedOpen = {};
+  thresholdAdvancedOpen = Object.create(null);
 
 var globalThresholds = [];
 var bulkPreviewCandidates = [];
+
+// Reject the prototype-pollution keys before any dynamic property write whose key
+// can originate from settings/catalog data, so a malicious sensor/reading name
+// (e.g. "__proto__") cannot reach Object.prototype.
+function isUnsafeKey(k) {
+  return k === "__proto__" || k === "constructor" || k === "prototype";
+}
 var snoozeDurationOptions = [300000, 900000, 3600000, 0];
 var dialPageColorPalette = [
   { foregroundColor: "#005128", highlightColor: "#009e00" },
@@ -203,7 +210,11 @@ function renderDialSettings() {
 
 function selectedPageIndex() {
   var list = document.getElementById("pageList");
-  return list.selectedIndex >= 0 ? list.selectedIndex : currentSettings.activeIndex || 0;
+  var raw = list.selectedIndex >= 0 ? list.selectedIndex : currentSettings.activeIndex;
+  var idx = parseInt(raw, 10);
+  // Always a non-negative integer: prevents a string key (e.g. "__proto__") from
+  // reaching currentSettings.pages[idx] as a prototype-pollution gadget.
+  return Number.isInteger(idx) && idx >= 0 ? idx : 0;
 }
 
 function updatePageButtons() {
@@ -358,7 +369,7 @@ function bindPageField(id, key, parser) {
   el.dataset.bound = "1";
   var handler = function () {
     var page = selectedPage();
-    if (!page) return;
+    if (!page || isUnsafeKey(key)) return;
     var raw = el.type === "checkbox" ? el.checked : el.value;
     page[key] = parser ? parser(raw) : raw;
     if (el.type === "range" && typeof positionRangeVal === "function") positionRangeVal(el);
@@ -375,6 +386,7 @@ function bindActionField(id, key, parser) {
   if (!el || el.dataset.bound) return;
   el.dataset.bound = "1";
   var handler = function () {
+    if (isUnsafeKey(key)) return;
     var raw = el.type === "checkbox" ? el.checked : el.value;
     currentSettings[key] = parser ? parser(raw) : raw;
     if (el.type === "range" && typeof positionRangeVal === "function") positionRangeVal(el);
@@ -422,7 +434,7 @@ function bindPageSettings() {
 
 function normalizeSnoozeDurations(values) {
   if (!Array.isArray(values)) return [];
-  var seen = {};
+  var seen = Object.create(null);
   values.forEach(function (value) {
     var parsed = parseInt(value, 10);
     if (!isNaN(parsed)) seen[parsed] = true;
@@ -449,7 +461,7 @@ function setSnoozePresetSelected(button, selected) {
 
 function applySnoozeDurationsToUI(page) {
   var selected = normalizeSnoozeDurations(page && page.snoozeDurations ? page.snoozeDurations : []);
-  var selectedMap = {};
+  var selectedMap = Object.create(null);
   selected.forEach(function (value) {
     selectedMap[String(value)] = true;
   });
@@ -504,7 +516,7 @@ function createThreshold(name) {
 }
 
 function updateThresholdField(threshold, key, value) {
-  if (!threshold) return;
+  if (!threshold || isUnsafeKey(key)) return;
   if (key === "enabled" || key === "sticky") {
     threshold[key] = value === true || value === "true";
     return;
@@ -966,7 +978,7 @@ function bulkCandidateKey(sensorUid, readingId, sourceProfileId) {
 }
 
 function existingBulkPageKeys() {
-  var seen = {};
+  var seen = Object.create(null);
   (currentSettings.pages || []).forEach(function (page) {
     if (!page || !page.sensorUid || page.readingId == null) return;
     seen[bulkCandidateKey(page.sensorUid, page.readingId, page.sourceProfileId)] = true;
@@ -986,7 +998,7 @@ function buildBulkCandidates(rule) {
   var seedSensor = selected.sensorUid;
   var seedCat = readingCategory(seed, seedSensor);
   var existing = existingBulkPageKeys();
-  var batchSeen = {};
+  var batchSeen = Object.create(null);
   var candidates = [];
   function addCandidate(sensorUid, reading) {
     var key = bulkCandidateKey(sensorUid, reading.id, currentSettings.sourceProfileId);
@@ -1021,7 +1033,7 @@ function buildBulkCandidates(rule) {
         bulkMatchText(r.label) === bulkMatchText(seed.label) &&
         sameBulkField(seed.type, r.type) && sameBulkField(seed.unit, r.unit);
     });
-    var sensorsSeen = {};
+    var sensorsSeen = Object.create(null);
     matched.forEach(function (r) { sensorsSeen[r.sensorUid] = 1; });
     if (Object.keys(sensorsSeen).length < 2) return []; // needs >1 matching sensor
     matched.forEach(function (r) { addCandidate(r.sensorUid, r); });

--- a/scripts/test-dial-pi.js
+++ b/scripts/test-dial-pi.js
@@ -313,8 +313,8 @@ function testBuildRefTraceableNotVisible() {
   const html = fs.readFileSync("com.moeilijk.lhm.sdPlugin/dial_pi.html", "utf8");
   // The build ref is traceable as a comment but must NOT occupy a visible PI row.
   assert(!html.includes('id="pluginBuildRef"'), "build ref must not be a visible PI row");
-  assert(/<!--[^>]*Build: 3c5e9b5 \+ V5-prep\.40/.test(html), "build ref present as a comment");
-  assert(html.includes('dial_pi.js?v=V5-prep.40'), "dial PI script is cache-busted with build ref");
+  assert(/<!--[^>]*Build: 3c5e9b5 \+ V5-prep\.41/.test(html), "build ref present as a comment");
+  assert(html.includes('dial_pi.js?v=V5-prep.41'), "dial PI script is cache-busted with build ref");
   assert(html.includes("Dial press"), "dial-press row present");
   assert(html.includes("Toggle overview"), "dial-press behavior visible");
   assert(html.includes('id="globalThresholdsSection" hidden'), "global thresholds section starts hidden");
@@ -350,6 +350,24 @@ function testThresholdHelpers() {
   assert(t.dwellMs === 1250, "dwellMs parsed");
   assert(t.sticky === true, "sticky boolean parsed");
   assert(t.bringToFront === true, "bringToFront boolean parsed");
+}
+
+// CodeQL js/prototype-polluting-assignment: dynamic property writes whose key can
+// come from settings/catalog data must not be able to reach Object.prototype.
+function testPrototypePollutionGuards() {
+  const sb = loadDialSandbox(autoStubElements({ pageList: { selectedIndex: -1 } }));
+  assert(sb.isUnsafeKey("__proto__") && sb.isUnsafeKey("constructor") && sb.isUnsafeKey("prototype"), "isUnsafeKey flags proto keys");
+  assert(!sb.isUnsafeKey("min") && !sb.isUnsafeKey("value"), "isUnsafeKey allows normal keys");
+
+  // A string activeIndex (e.g. "__proto__") must coerce to 0, never index pages["__proto__"].
+  sb.currentSettings = { activeIndex: "__proto__", pages: [{}] };
+  assert(sb.selectedPageIndex() === 0, "string activeIndex coerces to a safe integer");
+
+  // updateThresholdField must drop a "__proto__" key instead of assigning through it.
+  const t = sb.createThreshold("X");
+  sb.updateThresholdField(t, "__proto__", { polluted: true });
+  assert({}.polluted === undefined, "updateThresholdField does not pollute Object.prototype");
+  assert(t.value === undefined || !("polluted" in {}), "no prototype pollution side effect");
 }
 
 function testGlobalThresholdHelpersPerPage() {
@@ -713,6 +731,7 @@ const tests = [
   ["bulk preview list uses dark PI select style", testBulkPreviewListUsesDarkPiSelectStyle],
   ["snooze duration normalization", testSnoozeDurationNormalization],
   ["threshold helpers", testThresholdHelpers],
+  ["prototype-pollution guards", testPrototypePollutionGuards],
   ["global threshold helpers per page", testGlobalThresholdHelpersPerPage],
   ["global threshold section only when active", testGlobalThresholdSectionOnlyWhenActive],
   ["global threshold toggle click saves page suppression", testGlobalThresholdToggleClickSavesPageSuppression],


### PR DESCRIPTION
Resolves the 28 `js/prototype-polluting-assignment` CodeQL alerts in `dial_pi.js`.

## Root cause
`selectedPage()` indexed `currentSettings.pages[idx]` with `idx` derived from a user-controlled `activeIndex`; a string key like `__proto__` slipped past the numeric range guard and made the page object reachable as `Array.prototype`, so every subsequent write in `normalizePage` was flagged. Several map objects keyed by sensor/reading data were also writable through `__proto__`.

## Fix
- `selectedPageIndex()` always returns a non-negative integer (parseInt + `Number.isInteger`), so the pages array can never be indexed by a string key.
- Accumulator maps (`thresholdAdvancedOpen`, snooze dedup, selected-snooze map, bulk `seen`/`batchSeen`/`sensorsSeen`) use `Object.create(null)`.
- `bindPageField`, `bindActionField` and `updateThresholdField` reject `__proto__`/`constructor`/`prototype` keys before writing.

## Validation
- New behaviour test `prototype-pollution guards` in `test-dial-pi.js`.
- `make verify` + `scripts/verify-settings-pi.sh` green; build ref bumped to V5-prep.41.