### PR TITLE
chore: manifest 2.0.0.0 for the definitive 2.0 release

### DIFF
--- a/com.moeilijk.lhm.sdPlugin/manifest.json
+++ b/com.moeilijk.lhm.sdPlugin/manifest.json
@@ -100,7 +100,7 @@
 	"Icon": "pluginIcon",
 	"CategoryIcon": "categoryIcon",
 	"URL": "https://github.com/moeilijk/lhm-streamdeck",
-	"Version": "2.0.0.2",
+	"Version": "2.0.0.0",
 	"ApplicationsToMonitor": {
 		"windows": [
 			"LibreHardwareMonitor.EXE",


### PR DESCRIPTION
Sets `manifest.json` Version to `2.0.0.0` (4-digit build 0) for the definitive **v2.0.0** release, replacing the beta version `2.0.0.2`.

Release prep only; the tag and GitHub release follow per the release process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)